### PR TITLE
feat: add roles

### DIFF
--- a/telephony/fixtures/role.json
+++ b/telephony/fixtures/role.json
@@ -1,0 +1,28 @@
+[
+ {
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "home_page": null,
+  "is_custom": 0,
+  "modified": "2025-09-16 16:02:28.432733",
+  "name": "TP Agent",
+  "restrict_to_domain": null,
+  "role_name": "TP Agent",
+  "two_factor_auth": 0
+ },
+ {
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "home_page": null,
+  "is_custom": 0,
+  "modified": "2025-09-16 16:02:33.735393",
+  "name": "TP Manager",
+  "restrict_to_domain": null,
+  "role_name": "TP Manager",
+  "two_factor_auth": 0
+ }
+]

--- a/telephony/ftelephony/doctype/tp_call_log/tp_call_log.json
+++ b/telephony/ftelephony/doctype/tp_call_log/tp_call_log.json
@@ -136,7 +136,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-21 13:03:30.692064",
+ "modified": "2025-09-16 16:09:51.117835",
  "modified_by": "Administrator",
  "module": "FTelephony",
  "name": "TP Call Log",
@@ -151,7 +151,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Sales User",
+   "role": "TP Agent",
    "share": 1,
    "write": 1
   },
@@ -163,7 +163,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Sales Manager",
+   "role": "TP Manager",
    "share": 1,
    "write": 1
   }

--- a/telephony/ftelephony/doctype/tp_call_log/tp_call_log.json
+++ b/telephony/ftelephony/doctype/tp_call_log/tp_call_log.json
@@ -136,13 +136,25 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-16 16:09:51.117835",
+ "modified": "2025-10-10 15:03:12.638731",
  "modified_by": "Administrator",
  "module": "FTelephony",
  "name": "TP Call Log",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
   {
    "create": 1,
    "delete": 1,

--- a/telephony/ftelephony/doctype/tp_exotel_settings/tp_exotel_settings.json
+++ b/telephony/ftelephony/doctype/tp_exotel_settings/tp_exotel_settings.json
@@ -96,7 +96,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-07 09:10:24.333993",
+ "modified": "2025-09-16 16:08:11.364904",
  "modified_by": "Administrator",
  "module": "FTelephony",
  "name": "TP Exotel Settings",
@@ -118,7 +118,7 @@
    "email": 1,
    "print": 1,
    "read": 1,
-   "role": "Sales Manager",
+   "role": "TP Manager",
    "share": 1,
    "write": 1
   },

--- a/telephony/ftelephony/doctype/tp_telephony_agent/tp_telephony_agent.json
+++ b/telephony/ftelephony/doctype/tp_telephony_agent/tp_telephony_agent.json
@@ -99,7 +99,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-18 12:40:06.247707",
+ "modified": "2025-10-10 14:58:41.344291",
  "modified_by": "Administrator",
  "module": "FTelephony",
  "name": "TP Telephony Agent",
@@ -115,6 +115,30 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "TP Agent",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "TP Manager",
    "share": 1,
    "write": 1
   }

--- a/telephony/ftelephony/doctype/tp_twilio_settings/tp_twilio_settings.json
+++ b/telephony/ftelephony/doctype/tp_twilio_settings/tp_twilio_settings.json
@@ -124,7 +124,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-04 10:14:17.013637",
+ "modified": "2025-09-16 16:09:35.057408",
  "modified_by": "Administrator",
  "module": "FTelephony",
  "name": "TP Twilio Settings",
@@ -141,34 +141,21 @@
    "write": 1
   },
   {
-   "delete": 1,
-   "email": 1,
-   "permlevel": 1,
-   "print": 1,
-   "read": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
    "create": 1,
    "delete": 1,
    "email": 1,
    "print": 1,
    "read": 1,
-   "role": "Sales Manager",
+   "role": "TP Manager",
    "share": 1,
    "write": 1
   },
   {
-   "delete": 1,
    "email": 1,
-   "permlevel": 1,
    "print": 1,
    "read": 1,
-   "role": "Sales Manager",
-   "share": 1,
-   "write": 1
+   "role": "All",
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/telephony/hooks.py
+++ b/telephony/hooks.py
@@ -7,7 +7,7 @@ app_license = "agpl-3.0"
 
 
 fixtures = [
-	{"dt": "Role", "filters": [["role_name", "like", "TP%"]]},
+    {"dt": "Role", "filters": [["role_name", "like", "TP%"]]},
 ]
 
 # Apps

--- a/telephony/hooks.py
+++ b/telephony/hooks.py
@@ -5,6 +5,11 @@ app_description = "Telephony for Frappe apps"
 app_email = "pratik@frappe.io"
 app_license = "agpl-3.0"
 
+
+fixtures = [
+	{"dt": "Role", "filters": [["role_name", "like", "TP%"]]},
+]
+
 # Apps
 # ------------------
 


### PR DESCRIPTION
This PR introduces two new user roles **TP Agent** and **TP Manager**, to enable more granular control over telephony settings. These roles allow organizations to assign appropriate permissions based on user responsibilities, ensuring that telephony configurations are managed securely and efficiently.