### PR TITLE
feat: add send_otp/verify_otp entry points for other apps

### DIFF
--- a/telephony/email_otp.py
+++ b/telephony/email_otp.py
@@ -6,7 +6,10 @@ from frappe.rate_limiter import rate_limit
 from frappe.utils import split_emails, validate_email_address
 
 from telephony.otp import (
+    GENERATE_LIMIT,
     RATE_LIMIT_FIELD,
+    RATE_LIMIT_WINDOW,
+    VERIFY_LIMIT,
     clean_purpose,
     create_otp_record,
     generate_otp_code,
@@ -85,8 +88,15 @@ def dispatch_email_otp(email, message, subject):
 # a per-(IP, recipient) cap rather than the per-recipient one it is documented
 # as. Rotating IPs would then buy unlimited mail to a single inbox.
 @frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep
-@rate_limit_bucket("email", clean_email, "email:generate")
-@rate_limit(key=RATE_LIMIT_FIELD, limit=5, seconds=10 * 60, ip_based=False)
+@rate_limit_bucket(
+    "email", clean_email, "email:generate", GENERATE_LIMIT, RATE_LIMIT_WINDOW
+)
+@rate_limit(
+    key=RATE_LIMIT_FIELD,
+    limit=GENERATE_LIMIT,
+    seconds=RATE_LIMIT_WINDOW,
+    ip_based=False,
+)
 def generate_otp(email: str, purpose: str = "Verification"):
     """Generate an OTP and send it over email to the given address."""
     settings = get_email_otp_settings()
@@ -112,8 +122,12 @@ def generate_otp(email: str, purpose: str = "Verification"):
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep
-@rate_limit_bucket("email", clean_email, "email:verify")
-@rate_limit(key=RATE_LIMIT_FIELD, limit=10, seconds=10 * 60, ip_based=False)
+@rate_limit_bucket(
+    "email", clean_email, "email:verify", VERIFY_LIMIT, RATE_LIMIT_WINDOW
+)
+@rate_limit(
+    key=RATE_LIMIT_FIELD, limit=VERIFY_LIMIT, seconds=RATE_LIMIT_WINDOW, ip_based=False
+)
 def verify_otp(email: str, otp: str, purpose: str = "Verification"):
     """Verify an OTP previously sent to the given email address."""
     settings = get_email_otp_settings()

--- a/telephony/email_otp.py
+++ b/telephony/email_otp.py
@@ -19,40 +19,17 @@ from telephony.otp import (
 
 
 def clean_email(email: str) -> str:
-    """Canonicalize for rate-limit bucketing.
-
-    Must agree with what ``validate_single_email`` ultimately stores, or the
-    quota can be split across spellings of one address. So collapse the
-    separators frappe treats as separators, and reduce ``Foo <a@x.com>`` to the
-    bare address. This runs ahead of validation and on unvalidated input, so it
-    never throws — rejection is ``validate_single_email``'s job.
-
-    Unparseable input yields ``""``, never the raw string. Falling back to the
-    raw string is what made the bucket disagree with the recipient that gets
-    stored: ``parseaddr`` bails to ``("", "")`` on malformed input, so
-    ``victim@x.com,,`` bucketed on ``"victim@x.com,,"`` while
-    ``validate_email_address``'s per-piece fallback still resolved it to
-    ``victim@x.com`` — and every extra comma minted another untouched 5-per-10
-    minutes against the same inbox.
-    """
+    """Canonicalize for rate-limit bucketing. Must agree with what
+    ``validate_single_email`` stores, or one inbox gets a quota per spelling,
+    and must never throw — it yields ``""`` on unparseable input."""
     email = (email or "").replace("\n", ",").replace("\r", ",").strip().lower()
     return parseaddr(email)[1]
 
 
 def validate_single_email(email: str) -> str:
-    """Require exactly one address.
-
-    ``frappe.utils.validate_email_address`` parses with ``getaddresses()`` and
-    returns the addresses re-joined, so ``"a@x.com, b@y.com"`` passes. That
-    would land two addresses in a single ``TP OTP.recipient`` and produce a
-    malformed ``To:`` header, since ``sendmail`` does not re-split a list item.
-
-    The count has to be taken from what ``validate_email_address`` *returns*,
-    not from ``split_emails`` of the input: ``split_emails`` collapses ``\\n``
-    to a space before splitting, while ``validate_email_address`` turns it into
-    a separator. Checking the input therefore lets ``"a@x.com\\nb@y.com"``
-    through as "one" address and yields two.
-    """
+    """Require exactly one address: ``validate_email_address`` accepts a list
+    and returns it re-joined, which would store two recipients as one. Count
+    what it *returns*, not the input — the two disagree on newlines."""
     email = clean_email(email)
     if not email:
         frappe.throw(_("Please provide a valid email address."))
@@ -72,10 +49,8 @@ def get_email_otp_settings():
 
 
 def dispatch_email_otp(email, message, subject):
-    # redact_message_after_send: the queued body carries the cleartext code and
-    # Email Queue is retained for 30 days, so without this the OTP outlives its
-    # own expiry in a readable table — undoing the hashing in TP OTP, the same
-    # way an unredacted TP SMS Log would on the SMS side.
+    # redact_message_after_send: Email Queue keeps the body for 30 days, so
+    # without this the cleartext OTP outlives its own expiry.
     frappe.sendmail(
         recipients=[email],
         subject=subject,
@@ -84,9 +59,8 @@ def dispatch_email_otp(email, message, subject):
     )
 
 
-# ip_based=False: the default mixes the client IP into the identity, making this
-# a per-(IP, recipient) cap rather than the per-recipient one it is documented
-# as. Rotating IPs would then buy unlimited mail to a single inbox.
+# ip_based=False: the default mixes in the client IP, so rotating IPs would
+# buy unlimited mail to a single inbox.
 @frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep
 @rate_limit_bucket(
     "email", clean_email, "email:generate", GENERATE_LIMIT, RATE_LIMIT_WINDOW
@@ -111,8 +85,8 @@ def generate_otp(email: str, purpose: str = "Verification"):
     )
     subject = settings.email_otp_subject
 
-    # Record first, mirroring the SMS flow: the mail is queued in this same
-    # transaction, so a failure rolls both back together.
+    # Record first: the mail is queued in the same transaction, so a failure
+    # rolls both back together.
     create_otp_record(
         email, "Email", purpose, otp, expiry_seconds, settings.otp_max_attempts
     )

--- a/telephony/ftelephony/doctype/tp_otp/test_tp_otp.py
+++ b/telephony/ftelephony/doctype/tp_otp/test_tp_otp.py
@@ -26,7 +26,9 @@ PHONE_BUDGET = "+911234500004"
 PHONE_RESET = "+911234500005"
 PHONE_NORMALIZE = "+911234500006"
 PHONE_REDACT = "+911234500007"
+PHONE_OTHER = "+911234500008"
 TEST_EMAIL = "test-otp@example.com"
+TEST_EMAIL_OTHER = "other-otp@example.com"
 
 TEST_RECIPIENTS = [
     PHONE_VERIFY,
@@ -36,7 +38,9 @@ TEST_RECIPIENTS = [
     PHONE_RESET,
     PHONE_NORMALIZE,
     PHONE_REDACT,
+    PHONE_OTHER,
     TEST_EMAIL,
+    TEST_EMAIL_OTHER,
 ]
 
 
@@ -86,11 +90,32 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.addCleanup(settings.__exit__, None, None, None)
         frappe.clear_cache(doctype="TP OTP Settings")
 
+        # Off the request path rate_limit_bucket keeps its own counter in Redis,
+        # which outlives the transaction rollback the rest of this teardown
+        # relies on. Left behind it carries into whatever test runs next.
+        self.addCleanup(frappe.cache.delete_keys, "tp-otp-rl:")
+
         self.addCleanup(self._delete_test_records)
 
     def _delete_test_records(self):
         frappe.db.delete("TP OTP", {"recipient": ["in", TEST_RECIPIENTS]})
         frappe.db.delete("TP SMS Log", {"to": ["in", TEST_RECIPIENTS]})
+
+    def _capture_bucket(self, seen, wrapped=None):
+        """Record the rate-limit bucket while the endpoint is still running.
+
+        call_channel_endpoint restores form_dict on the way out, so the bucket
+        cannot be read after the call — which is the whole point of it, but it
+        means a test has to look from inside.
+        """
+        from telephony.otp import RATE_LIMIT_FIELD
+
+        def side_effect(*args, **kwargs):
+            seen.append(frappe.form_dict.get(RATE_LIMIT_FIELD))
+            if wrapped:
+                return wrapped(*args, **kwargs)
+
+        return side_effect
 
     def _log_sent_sms(self, to, message, purpose="OTP"):
         """Stand in for dispatch_sms, but still write a real TP SMS Log so the
@@ -347,12 +372,21 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         not leave the key *empty*, which makes rate_limit throw its own "Either
         key or IP flag is required" in place of the endpoint's message."""
         from telephony.email_otp import clean_email
-        from telephony.otp import INVALID_RECIPIENT, RATE_LIMIT_FIELD, rate_limit_bucket
+        from telephony.otp import (
+            INVALID_RECIPIENT,
+            RATE_LIMIT_FIELD,
+            RATE_LIMIT_WINDOW,
+            rate_limit_bucket,
+        )
 
         self.addCleanup(frappe.form_dict.pop, "email", None)
         self.addCleanup(frappe.form_dict.pop, RATE_LIMIT_FIELD, None)
 
-        @rate_limit_bucket("email", clean_email, "email:generate")
+        # generous limit: this is asserting the bucket key, not the cap, and off
+        # the request path rate_limit_bucket now enforces the cap itself.
+        @rate_limit_bucket(
+            "email", clean_email, "email:generate", 100, RATE_LIMIT_WINDOW
+        )
         def endpoint(email=None):
             return frappe.form_dict[RATE_LIMIT_FIELD]
 
@@ -878,3 +912,202 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
         result = send_sms(to=PHONE_VERIFY, message="hi")
         self.assertEqual(result["status"], "Sent")
+
+    @patch("telephony.email_otp.dispatch_email_otp")
+    @patch("telephony.email_otp.generate_otp_code", return_value="777666")
+    def test_send_and_verify_otp_resolve_the_channel(
+        self, mock_generate_code, mock_dispatch_email
+    ):
+        """The entry point other apps use: the same flow the endpoints run,
+        reached with a channel name instead of a channel-specific field."""
+        from telephony.otp import send_otp, verify_otp
+
+        purpose = "Loan Lead LN-LEAD-00001"
+
+        result = send_otp(TEST_EMAIL, "Email", purpose=purpose)
+        self.assertEqual(set(result), {"sent", "expires_in"})
+        mock_dispatch_email.assert_called_once()
+
+        # the purpose scopes the code: the same recipient on the same channel
+        # under another purpose must not match it
+        self.assertEqual(
+            verify_otp(TEST_EMAIL, "Email", "777666", purpose="Verification"),
+            GENERIC_FAILURE,
+        )
+        self.assertEqual(
+            verify_otp(TEST_EMAIL, "Email", "777666", purpose=purpose),
+            {"verified": True},
+        )
+
+    def test_unknown_channel_is_rejected(self):
+        """The channel names a module to import, and callers pass it through
+        from their own request handlers."""
+        from telephony.otp import send_otp, verify_otp
+
+        for channel in ("Carrier Pigeon", "sms", "", None):
+            with self.assertRaises(frappe.ValidationError):
+                send_otp(TEST_EMAIL, channel)
+            with self.assertRaises(frappe.ValidationError):
+                verify_otp(TEST_EMAIL, channel, "777666")
+
+    @patch("telephony.email_otp.dispatch_email_otp")
+    @patch("telephony.email_otp.generate_otp_code", return_value="777666")
+    def test_send_otp_buckets_its_rate_limit_per_recipient(
+        self, mock_generate_code, mock_dispatch_email
+    ):
+        """A server-side caller populates no form_dict, so unless send_otp
+        publishes the recipient there itself, every recipient falls into the
+        shared INVALID_RECIPIENT bucket: five sends to one recipient would then
+        block sends to every other one, and none would be capped on their own."""
+        from telephony.otp import send_otp
+
+        seen = []
+        mock_dispatch_email.side_effect = self._capture_bucket(seen)
+
+        self._drive_rate_limiter("/api/method/telephony.otp.send_otp")
+
+        # limit is 5 per 10 minutes, per recipient
+        for _ in range(5):
+            send_otp(TEST_EMAIL, "Email")
+
+        self.assertEqual(seen[-1], f"email:generate:{TEST_EMAIL}")
+
+        with self.assertRaises(frappe.RateLimitExceededError):
+            send_otp(TEST_EMAIL, "Email")
+
+        # a different recipient keeps a budget of their own
+        send_otp(TEST_EMAIL_OTHER, "Email")
+
+    @patch("telephony.twilio.sms.dispatch_sms")
+    @patch("telephony.twilio.sms.generate_otp_code", return_value="123456")
+    def test_send_and_verify_otp_resolve_the_sms_channel(
+        self, mock_generate_code, mock_dispatch_sms
+    ):
+        """The SMS half of the channel registry: the recipient reaches the
+        endpoint under the field name OTP_CHANNELS claims it takes, so a rename
+        in twilio.sms fails here rather than at a caller."""
+        from telephony.otp import send_otp, verify_otp
+
+        mock_dispatch_sms.side_effect = self._log_sent_sms
+        purpose = "Loan Lead LN-LEAD-00001"
+
+        result = send_otp(PHONE_VERIFY, "SMS", purpose=purpose)
+        self.assertEqual(set(result), {"sent", "expires_in"})
+        mock_dispatch_sms.assert_called_once()
+        self.assertEqual(mock_dispatch_sms.call_args.args[0], PHONE_VERIFY)
+
+        self.assertEqual(
+            verify_otp(PHONE_VERIFY, "SMS", "123456", purpose="Verification"),
+            GENERIC_FAILURE,
+        )
+        self.assertEqual(
+            verify_otp(PHONE_VERIFY, "SMS", "123456", purpose=purpose),
+            {"verified": True},
+        )
+
+    @patch("telephony.twilio.sms.dispatch_sms")
+    @patch("telephony.twilio.sms.generate_otp_code", return_value="123456")
+    def test_send_otp_buckets_its_rate_limit_per_recipient_over_sms(
+        self, mock_generate_code, mock_dispatch_sms
+    ):
+        """Same per-recipient bucketing as the email case, on the channel whose
+        recipient field differs from it — an unset phone_number would put every
+        number in the shared INVALID_RECIPIENT bucket."""
+        from telephony.otp import send_otp
+
+        seen = []
+        mock_dispatch_sms.side_effect = self._capture_bucket(seen, self._log_sent_sms)
+
+        self._drive_rate_limiter("/api/method/telephony.otp.send_otp")
+
+        # limit is 5 per 10 minutes, per recipient
+        for _ in range(5):
+            send_otp(PHONE_VERIFY, "SMS")
+
+        self.assertEqual(seen[-1], f"sms:generate:{PHONE_VERIFY}")
+
+        with self.assertRaises(frappe.RateLimitExceededError):
+            send_otp(PHONE_VERIFY, "SMS")
+
+        # a different recipient keeps a budget of their own
+        send_otp(PHONE_OTHER, "SMS")
+
+    @patch("telephony.email_otp.dispatch_email_otp")
+    @patch("telephony.email_otp.generate_otp_code", return_value="777666")
+    def test_send_otp_leaves_form_dict_as_it_found_it(
+        self, mock_generate_code, mock_dispatch_email
+    ):
+        """form_dict belongs to the caller's request, and send_otp only borrows
+        it to reach the endpoint's rate limiter.
+
+        Left behind, the recipient is PII sitting in a dict frappe writes wholesale
+        into Error Log metadata on any later unhandled exception in the same
+        request — redacted only for credential-looking keys, which 'email' and
+        'phone_number' are not. A caller that posted a document name and nothing
+        else would have leaked that document's contact details on an unrelated
+        failure. It also silently replaced any parameter the caller had under the
+        same name.
+        """
+        from telephony.otp import RATE_LIMIT_FIELD, send_otp
+
+        self.addCleanup(frappe.form_dict.pop, "email", None)
+        self.addCleanup(frappe.form_dict.pop, RATE_LIMIT_FIELD, None)
+
+        # a caller with an 'email' parameter of its own must get it back intact
+        frappe.form_dict.email = "caller-value"
+        send_otp(TEST_EMAIL, "Email")
+        self.assertEqual(frappe.form_dict.email, "caller-value")
+
+        # and one that never had the key must not acquire it
+        frappe.form_dict.pop("email", None)
+        frappe.form_dict.pop(RATE_LIMIT_FIELD, None)
+        send_otp(TEST_EMAIL_OTHER, "Email")
+        self.assertNotIn("email", frappe.form_dict)
+        self.assertNotIn(RATE_LIMIT_FIELD, frappe.form_dict)
+
+    @patch("telephony.email_otp.dispatch_email_otp")
+    @patch("telephony.email_otp.generate_otp_code", return_value="777666")
+    def test_send_otp_is_rate_limited_without_a_request(
+        self, mock_generate_code, mock_dispatch_email
+    ):
+        """frappe's @rate_limit returns early when frappe.request is None, so on
+        a background job — the natural place for an app to dispatch OTPs — the
+        per-recipient cap was not merely wrong but absent."""
+        from telephony.otp import send_otp
+
+        # frappe.request is an unbound LocalProxy here, not None — falsy, which
+        # is exactly what rate_limit and rate_limit_bucket both branch on.
+        self.assertFalse(frappe.request, "this test must run off the request path")
+
+        for _ in range(5):
+            send_otp(TEST_EMAIL, "Email")
+
+        with self.assertRaises(frappe.RateLimitExceededError):
+            send_otp(TEST_EMAIL, "Email")
+
+        # still bucketed per recipient, not one shared counter
+        send_otp(TEST_EMAIL_OTHER, "Email")
+
+    @patch("telephony.twilio.sms.dispatch_sms")
+    @patch("telephony.twilio.sms.generate_otp_code", return_value="123456")
+    def test_non_string_recipient_is_rejected_by_type_not_by_crash(
+        self, mock_generate_code, mock_dispatch_sms
+    ):
+        """A mistyped recipient must fail as a type error, not as an
+        AttributeError from inside the rate-limit decorator.
+
+        The normalizers open on ``.strip()``, and send_otp writes its recipient
+        into form_dict verbatim, so an int looked like it would reach one. It
+        does not: @frappe.whitelist validates annotated arguments and is the
+        outermost decorator, so it rejects the int before rate_limit_bucket
+        runs. Pinned here because that ordering is what makes it safe, and
+        nothing else in the file asserts it.
+        """
+        from telephony.otp import send_otp
+
+        mock_dispatch_sms.side_effect = self._log_sent_sms
+
+        with self.assertRaises(frappe.exceptions.FrappeTypeError):
+            send_otp(911234500001, "SMS")
+
+        mock_dispatch_sms.assert_not_called()

--- a/telephony/ftelephony/doctype/tp_otp/test_tp_otp.py
+++ b/telephony/ftelephony/doctype/tp_otp/test_tp_otp.py
@@ -45,25 +45,19 @@ TEST_RECIPIENTS = [
 
 
 class IntegrationTestTPOTP(IntegrationTestCase):
-    """Integration tests for TP OTP, exercising the SMS and Email OTP flows
-    end-to-end with the actual Twilio/email dispatch mocked out."""
+    """SMS and Email OTP flows end-to-end, with dispatch mocked out."""
 
     def setUp(self):
         super().setUp()
 
-        # TP OTP Settings.validate() confirms sms_from_number against the live
-        # Twilio account. These tests never reach Twilio, so stub that one
-        # check rather than skipping validation wholesale — the OTP parameter
-        # validation still runs.
+        # Stub only the live-Twilio check, so the rest of validate() still runs.
         patcher = patch.object(
             TPOTPSettings, "validate_sms_from_number", return_value=None
         )
         patcher.start()
         self.addCleanup(patcher.stop)
 
-        # TP Twilio Settings.validate() authenticates against the live Twilio
-        # API and on_update() provisions API keys there; neither is reachable
-        # from tests. Stub both so change_settings can drive the doc normally.
+        # Both reach the live Twilio API; stub them so change_settings works.
         for method in ("validate_twilio_account", "on_update"):
             twilio_patcher = patch.object(TPTwilioSettings, method, return_value=None)
             twilio_patcher.start()
@@ -90,8 +84,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.addCleanup(settings.__exit__, None, None, None)
         frappe.clear_cache(doctype="TP OTP Settings")
 
-        # Off the request path the counter lives in Redis, which outlives the
-        # transaction rollback the rest of this teardown relies on.
+        # This counter lives in Redis, which outlives the transaction rollback.
         self.addCleanup(frappe.cache.delete_keys, "tp-otp-rl:")
 
         self.addCleanup(self._delete_test_records)
@@ -101,8 +94,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         frappe.db.delete("TP SMS Log", {"to": ["in", TEST_RECIPIENTS]})
 
     def _capture_bucket(self, seen, wrapped=None):
-        """Record the rate-limit bucket while the endpoint is still running:
-        call_channel_endpoint restores form_dict on the way out."""
+        """Read the bucket from inside the endpoint: call_channel_endpoint
+        restores form_dict on the way out."""
         from telephony.otp import RATE_LIMIT_FIELD
 
         def side_effect(*args, **kwargs):
@@ -113,8 +106,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         return side_effect
 
     def _log_sent_sms(self, to, message, purpose="OTP"):
-        """Stand in for dispatch_sms, but still write a real TP SMS Log so the
-        redaction behaviour under test is exercised."""
+        """Stand in for dispatch_sms, but write a real TP SMS Log."""
         from telephony.twilio.sms import create_sms_log
 
         return create_sms_log(
@@ -153,8 +145,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_generate_response_never_carries_the_code(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """The response is returned to unauthenticated callers, so it must not
-        echo the OTP back under any site configuration."""
+        """The response goes to guests, so it must never echo the OTP."""
         from telephony.twilio.sms import generate_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -189,8 +180,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_regenerating_otp_does_not_reset_attempt_budget(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """Requesting a fresh OTP must not hand out a new attempt budget while
-        the previous one is still live, else the max-attempts cap is toothless."""
+        """A resend must not hand out a new attempt budget while the previous
+        OTP is still live."""
         from telephony.twilio.sms import generate_otp, verify_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -205,9 +196,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
             GENERIC_FAILURE,
         )
 
-        # Resending is refused outright rather than issuing a code that starts
-        # at the cap: no SMS is paid for, and no new row is created to carry a
-        # refreshed expires_at.
+        # Refused outright: no SMS paid for, no row with a refreshed expiry.
         with self.assertRaises(frappe.ValidationError):
             generate_otp(phone_number=PHONE_BUDGET, purpose="Login")
 
@@ -228,10 +217,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_resending_while_locked_out_does_not_extend_the_lockout(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """Carrying attempts forward onto a row with a *fresh* expires_at made
-        the lockout self-perpetuating: every resend inside the window pushed the
-        expiry a full window further out while billing for a dead code, so a user
-        who reacted by retrying — the normal reaction — never got back in."""
+        """A resend inside the lockout window must not push the expiry a full
+        window further out, or retrying keeps the user locked out forever."""
         from telephony.twilio.sms import generate_otp, verify_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -278,8 +265,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_attempt_budget_resets_once_window_lapses(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """The carry-forward above must not become a permanent lockout: once the
-        previous OTP is no longer live, a fresh request starts clean."""
+        """The carry-forward must not become a permanent lockout."""
         from telephony.twilio.sms import generate_otp, verify_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -318,8 +304,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_otp_body_is_not_written_to_sms_log(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """TP SMS Log is readable by TP Agent and kept for 90 days, so storing
-        the rendered code there would defeat hashing it in TP OTP."""
+        """TP SMS Log is agent-readable and kept 90 days."""
         from telephony.twilio.sms import generate_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -342,8 +327,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     @patch("telephony.twilio.sms.dispatch_sms")
     @patch("telephony.twilio.sms.generate_otp_code", return_value="123456")
     def test_rate_limit_key_is_normalized(self, mock_generate_code, mock_dispatch_sms):
-        """frappe.rate_limit buckets on form_dict[key] verbatim, so the key has
-        to be canonical or the send cap is bypassable by reformatting."""
+        """rate_limit buckets on form_dict[key] verbatim, so the key has to be
+        canonical or the cap is bypassable by reformatting."""
         from telephony.otp import RATE_LIMIT_FIELD
         from telephony.twilio.sms import generate_otp
 
@@ -361,11 +346,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         )
 
     def test_unusable_recipients_share_one_bucket(self):
-        """A recipient that cannot be canonicalized must not become its own
-        bucket: with the raw string as the key, varying the garbage minted fresh
-        quota against the address it would ultimately resolve to. They also must
-        not leave the key *empty*, which makes rate_limit throw its own "Either
-        key or IP flag is required" in place of the endpoint's message."""
+        """Uncanonicalizable recipients share one bucket, so varying the garbage
+        cannot mint quota — but the key must not be left empty either."""
         from telephony.email_otp import clean_email
         from telephony.otp import (
             INVALID_RECIPIENT,
@@ -377,8 +359,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.addCleanup(frappe.form_dict.pop, "email", None)
         self.addCleanup(frappe.form_dict.pop, RATE_LIMIT_FIELD, None)
 
-        # generous limit: this is asserting the bucket key, not the cap, and off
-        # the request path rate_limit_bucket now enforces the cap itself.
+        # generous limit: this asserts the bucket key, not the cap.
         @rate_limit_bucket(
             "email", clean_email, "email:generate", 100, RATE_LIMIT_WINDOW
         )
@@ -401,10 +382,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_email_bucket_agrees_with_the_recipient_that_would_be_stored(
         self, mock_dispatch_email
     ):
-        """clean_email used to fall back to the raw string when parseaddr bailed,
-        while validate_email_address's per-piece fallback still resolved it — so
-        "victim@x.com,," bucketed separately but delivered to victim@x.com, and
-        each extra comma bought another untouched 5-per-10-minutes."""
+        """The bucket must be the address that gets stored: otherwise
+        "victim@x.com,," buckets apart but still delivers to victim@x.com."""
         from telephony.email_otp import clean_email
         from telephony.email_otp import generate_otp as generate_email_otp
 
@@ -415,11 +394,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
         mock_dispatch_email.assert_not_called()
 
-        # The invariant, stated directly: for anything that *is* accepted, the
-        # bucket clean_email produces has to be the recipient that gets stored.
-        # parseaddr resolves more than it rejects — "a@x.com," loses the comma,
-        # "a@x.com x" becomes "a@x.comx" — and that is fine as long as the two
-        # sides agree, which is what this checks.
+        # The invariant: for anything accepted, the bucket clean_email produces
+        # has to be the recipient that gets stored.
         from telephony.email_otp import validate_single_email
 
         for accepted in (TEST_EMAIL, f"{TEST_EMAIL},", f" {TEST_EMAIL.upper()} "):
@@ -457,8 +433,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_email_otp_is_case_insensitive(
         self, mock_generate_code, mock_dispatch_email
     ):
-        """Case variants must resolve to one recipient, both for storage and for
-        rate-limit bucketing."""
+        """Case variants must resolve to one recipient."""
         from telephony.email_otp import generate_otp as generate_email_otp
         from telephony.email_otp import verify_otp as verify_email_otp
 
@@ -476,8 +451,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
     @patch("telephony.email_otp.dispatch_email_otp")
     def test_email_otp_rejects_multiple_addresses(self, mock_dispatch_email):
-        """validate_email_address() accepts a comma-separated list and returns
-        it re-joined, which would store two addresses as one recipient."""
+        """validate_email_address() accepts a list and returns it re-joined,
+        which would store two addresses as one recipient."""
         from telephony.email_otp import generate_otp as generate_email_otp
 
         with self.assertRaises(frappe.ValidationError):
@@ -489,9 +464,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
     @patch("telephony.email_otp.dispatch_email_otp")
     def test_email_otp_rejects_newline_separated_addresses(self, mock_dispatch_email):
-        """A newline is the separator that slips past a split_emails() count:
-        split_emails collapses \\n to a space before splitting, while
-        validate_email_address turns it into a comma and returns both."""
+        """A newline is the separator that slips past a split_emails() count."""
         from telephony.email_otp import generate_otp as generate_email_otp
 
         for separator in ("\n", "\r"):
@@ -504,8 +477,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         mock_dispatch_email.assert_not_called()
 
     def test_email_otp_is_redacted_from_the_email_queue(self):
-        """Email Queue keeps the rendered body for 30 days, so the queued OTP
-        must not outlive its own expiry in cleartext."""
+        """Email Queue keeps the body for 30 days."""
         import inspect
 
         from telephony.email_otp import dispatch_email_otp
@@ -522,9 +494,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
     def test_clean_phone_number_rejects_non_ascii_digits(self):
         """str.isdigit() is true for fullwidth/Arabic-Indic digits, which
-        MariaDB's utf8mb4_unicode_ci then compares equal to their ASCII form —
-        so they must not survive normalization. Rejected, not dropped: dropping
-        them would leave a shorter number that is still deliverable."""
+        utf8mb4_unicode_ci then compares equal to their ASCII form."""
         from telephony.twilio.sms import clean_phone_number
 
         # fullwidth ９１ and Arabic-Indic ٩١ both pass str.isdigit()
@@ -533,9 +503,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.assertEqual(clean_phone_number("+91 12345-00001"), "+911234500001")
 
     def test_clean_phone_number_rejects_rather_than_absorbing_stray_input(self):
-        """Silently dropping unexpected characters rewrites one number into a
-        different, deliverable one — so the OTP reaches a stranger who never
-        asked for it. "1. +919876543210" used to yield +1919876543210."""
+        """Dropping unexpected characters rewrites one number into a different,
+        deliverable one: "1. +919876543210" yielded +1919876543210."""
         from telephony.twilio.sms import clean_phone_number
 
         for rejected in (
@@ -549,8 +518,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
     def test_clean_phone_number_canonicalizes_to_one_e164_string(self):
         """Every spelling of one number must collapse to one string: it is both
-        the TP OTP lookup key and the rate-limit bucket, so `91...` and `+91...`
-        being distinct meant one number held two of each."""
+        the TP OTP lookup key and the rate-limit bucket."""
         from telephony.twilio.sms import clean_phone_number
 
         canonical = "+917977396938"
@@ -564,8 +532,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         ):
             self.assertEqual(clean_phone_number(spelling), canonical, spelling)
 
-        # a bare "+" must come back empty so the "provide a valid phone number"
-        # checks still fire, rather than handing Twilio a "+"
+        # a bare "+" must come back empty, so the downstream checks still fire
         for empty in ("", "   ", "+", "++", None):
             self.assertEqual(clean_phone_number(empty), "")
 
@@ -574,8 +541,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_otp_verifies_regardless_of_number_spelling(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """The live consequence of the above: a code requested with one
-        spelling has to verify with another."""
+        """A code requested with one spelling has to verify with another."""
         from telephony.twilio.sms import generate_otp, verify_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -604,9 +570,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     @patch("telephony.twilio.sms.Twilio")
     def test_dispatch_sms_failure_is_generic_and_audited(self, MockTwilio):
         """The raised message must not carry Twilio internals, and the Failed
-        row must still be written — via Redis, not via a commit. A commit here
-        would also commit the *caller's* pending writes, so a Twilio outage
-        would persist a calling doc hook's half-finished work."""
+        row must still be written — via Redis, not via a commit."""
         from telephony.twilio.sms import dispatch_sms
 
         client = MockTwilio.connect.return_value.twilio_client
@@ -639,7 +603,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     @patch("telephony.twilio.sms.Twilio")
     def test_dispatch_sms_failure_payload_survives_json(self, MockTwilio):
         """deferred_insert json.dumps() the record, so a datetime in it would
-        raise TypeError and lose the audit row outright."""
+        lose the audit row outright."""
         import json
 
         from telephony.twilio.sms import build_sms_log
@@ -651,9 +615,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
     @patch("telephony.twilio.sms.Twilio")
     def test_dispatch_sms_rejects_input_it_could_not_audit(self, MockTwilio):
-        """`to` and `message` are mandatory on TP SMS Log, so an empty one made
-        the failure path's own audit write raise MandatoryError — losing the
-        Failed row and masking the real error. Reject before sending instead."""
+        """Both are mandatory on TP SMS Log, so an empty one would make the
+        failure path's own audit write raise and mask the real error."""
         from telephony.twilio.sms import dispatch_sms
 
         client = MockTwilio.connect.return_value.twilio_client
@@ -670,11 +633,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.assertFalse(frappe.db.exists("TP SMS Log", {"to": ""}))
 
     def _drive_rate_limiter(self, path, cmd=None):
-        """The limiter is inert without frappe.request, so give it one.
-
-        `cmd` is left unset by default because that is the /api/v2 shape: only
-        /api/v1 populates it, and rate_limit's cache key interpolates it.
-        """
+        """The limiter is inert without frappe.request, so give it one. `cmd`
+        is unset by default because that is the /api/v2 shape."""
         from frappe.utils import set_request
 
         from telephony.otp import RATE_LIMIT_FIELD
@@ -696,8 +656,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_rate_limit_actually_throttles_sends(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """The limiter is inert without frappe.request, so the other tests never
-        exercise it. Drive it with a request context and prove it fires."""
+        """The limiter is inert without frappe.request; drive it with one."""
         from telephony.twilio.sms import generate_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -718,9 +677,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self, mock_generate_code, mock_dispatch_sms
     ):
         """rate_limit defaults to ip_based=True, which makes the identity
-        `ip:recipient` — so the cap documented as per-recipient was really
-        per-(IP, recipient), and rotating IPs bought unlimited SMS to one number
-        along with the Twilio bill for them."""
+        `ip:recipient`, so rotating IPs buys unlimited SMS to one number."""
         from telephony.twilio.sms import generate_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -742,10 +699,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_generate_and_verify_do_not_share_a_rate_limit_counter(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """rate_limit's cache key is rl:{form_dict.cmd}:{identity}:{seconds} and
-        only /api/v1 sets cmd. Over /api/v2 it renders as None, so generate and
-        verify — same key, same identity, same 600s window — collided on one
-        counter and four failed verifies blocked the next resend."""
+        """rate_limit's cache key interpolates cmd, which only /api/v1 sets, so
+        over /api/v2 generate and verify collide on one counter."""
         from telephony.twilio.sms import generate_otp, verify_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -772,9 +727,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
 
     @patch("telephony.twilio.sms.dispatch_sms")
     def test_send_sms_is_rate_limited_and_configurable(self, mock_dispatch_sms):
-        """send_sms sends arbitrary content to arbitrary numbers at real cost,
-        so it needs a cap — but a hardcoded one would break bulk senders, hence
-        the setting."""
+        """send_sms costs real money, so it needs a configurable cap."""
         from frappe.utils import set_request
 
         from telephony.twilio.sms import get_send_sms_limit, send_sms
@@ -814,9 +767,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
             self.assertGreater(get_send_sms_limit(), 1000)
 
     def test_send_sms_limit_does_not_fail_open_when_unconfigured(self):
-        """A Single holds no value for a field until first save, so an existing
-        site reads None here. That must not be read as "unlimited" — only an
-        explicit 0 opts out."""
+        """An unsaved Single reads None here, which must not mean "unlimited"."""
         from telephony.twilio.sms import DEFAULT_SEND_SMS_LIMIT, get_send_sms_limit
 
         with patch("frappe.get_cached_value", return_value=None):
@@ -829,8 +780,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
             self.assertEqual(get_send_sms_limit(), 25)
 
     def test_verify_pays_the_kdf_cost_on_every_failure_path(self):
-        """The failure body is uniform; the latency has to be too, or a guest
-        can time-probe which recipients have a live OTP."""
+        """The failure body is uniform; the latency has to be too."""
         from telephony import otp as otp_module
 
         recipient = PHONE_ATTEMPTS
@@ -861,10 +811,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
             self.assertEqual(mock_equalize.call_count, 3)
 
     def test_guest_may_call_otp_endpoints_but_not_send_sms(self):
-        """Guest access is decided by frappe.is_whitelisted against the exact
-        object registered at decoration time. Since normalize_form_field wraps
-        the function *under* @frappe.whitelist, a mistake in that stacking would
-        silently drop guest registration — so assert it directly."""
+        """Guest access is decided against the exact object registered at
+        decoration time, so a mistake in decorator stacking drops it silently."""
         from telephony import email_otp
         from telephony.twilio import sms
 
@@ -882,8 +830,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
             with self.assertRaises(frappe.PermissionError):
                 frappe.is_whitelisted(sms.send_sms)
 
-        # POST-only: GET skips Frappe's CSRF check, so a state-changing
-        # whitelisted method must not accept it.
+        # POST-only: GET skips Frappe's CSRF check.
         for fn in [*guest_callable, sms.send_sms]:
             self.assertEqual(
                 tuple(frappe.allowed_http_methods_for_whitelisted_func[fn]), ("POST",)
@@ -913,8 +860,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_send_and_verify_otp_resolve_the_channel(
         self, mock_generate_code, mock_dispatch_email
     ):
-        """The entry point other apps use: the same flow the endpoints run,
-        reached with a channel name instead of a channel-specific field."""
+        """The entry point other apps use, reached with a channel name."""
         from telephony.otp import send_otp, verify_otp
 
         purpose = "Loan Lead LN-LEAD-00001"
@@ -923,8 +869,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.assertEqual(set(result), {"sent", "expires_in"})
         mock_dispatch_email.assert_called_once()
 
-        # the purpose scopes the code: the same recipient on the same channel
-        # under another purpose must not match it
+        # the purpose scopes the code: another purpose must not match it
         self.assertEqual(
             verify_otp(TEST_EMAIL, "Email", "777666", purpose="Verification"),
             GENERIC_FAILURE,
@@ -950,7 +895,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self, mock_generate_code, mock_dispatch_email
     ):
         """Without send_otp publishing the recipient into form_dict, every
-        recipient shares the INVALID_RECIPIENT bucket and one site-wide cap."""
+        recipient shares one site-wide cap."""
         from telephony.otp import send_otp
 
         seen = []
@@ -1027,12 +972,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_send_otp_leaves_form_dict_as_it_found_it(
         self, mock_generate_code, mock_dispatch_email
     ):
-        """form_dict belongs to the caller's request; send_otp only borrows it
-        to reach the endpoint's rate limiter.
-
-        Left behind, the recipient is PII that frappe writes into Error Log
-        metadata on any later unhandled exception in the same request.
-        """
+        """Left behind, the recipient is PII that frappe writes into Error Log
+        metadata on any later unhandled exception in the same request."""
         from telephony.otp import RATE_LIMIT_FIELD, send_otp
 
         self.addCleanup(frappe.form_dict.pop, "email", None)
@@ -1059,8 +1000,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         a background job the cap is not merely wrong but absent."""
         from telephony.otp import send_otp
 
-        # frappe.request is an unbound LocalProxy here, not None — falsy, which
-        # is exactly what rate_limit and rate_limit_bucket both branch on.
+        # an unbound LocalProxy here, not None — falsy either way
         self.assertFalse(frappe.request, "this test must run off the request path")
 
         for _ in range(5):
@@ -1078,12 +1018,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self, mock_generate_code, mock_dispatch_sms
     ):
         """A mistyped recipient must fail as a type error, not as an
-        AttributeError from inside the rate-limit decorator.
-
-        @frappe.whitelist is the outermost decorator and validates annotated
-        arguments, so it rejects the int before rate_limit_bucket runs. Pinned
-        because that ordering is what makes it safe.
-        """
+        AttributeError from inside the rate-limit decorator."""
         from telephony.otp import send_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms

--- a/telephony/ftelephony/doctype/tp_otp/test_tp_otp.py
+++ b/telephony/ftelephony/doctype/tp_otp/test_tp_otp.py
@@ -90,9 +90,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self.addCleanup(settings.__exit__, None, None, None)
         frappe.clear_cache(doctype="TP OTP Settings")
 
-        # Off the request path rate_limit_bucket keeps its own counter in Redis,
-        # which outlives the transaction rollback the rest of this teardown
-        # relies on. Left behind it carries into whatever test runs next.
+        # Off the request path the counter lives in Redis, which outlives the
+        # transaction rollback the rest of this teardown relies on.
         self.addCleanup(frappe.cache.delete_keys, "tp-otp-rl:")
 
         self.addCleanup(self._delete_test_records)
@@ -102,12 +101,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         frappe.db.delete("TP SMS Log", {"to": ["in", TEST_RECIPIENTS]})
 
     def _capture_bucket(self, seen, wrapped=None):
-        """Record the rate-limit bucket while the endpoint is still running.
-
-        call_channel_endpoint restores form_dict on the way out, so the bucket
-        cannot be read after the call — which is the whole point of it, but it
-        means a test has to look from inside.
-        """
+        """Record the rate-limit bucket while the endpoint is still running:
+        call_channel_endpoint restores form_dict on the way out."""
         from telephony.otp import RATE_LIMIT_FIELD
 
         def side_effect(*args, **kwargs):
@@ -940,8 +935,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         )
 
     def test_unknown_channel_is_rejected(self):
-        """The channel names a module to import, and callers pass it through
-        from their own request handlers."""
+        """The channel names a module to import, so it is validated first."""
         from telephony.otp import send_otp, verify_otp
 
         for channel in ("Carrier Pigeon", "sms", "", None):
@@ -955,10 +949,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_send_otp_buckets_its_rate_limit_per_recipient(
         self, mock_generate_code, mock_dispatch_email
     ):
-        """A server-side caller populates no form_dict, so unless send_otp
-        publishes the recipient there itself, every recipient falls into the
-        shared INVALID_RECIPIENT bucket: five sends to one recipient would then
-        block sends to every other one, and none would be capped on their own."""
+        """Without send_otp publishing the recipient into form_dict, every
+        recipient shares the INVALID_RECIPIENT bucket and one site-wide cap."""
         from telephony.otp import send_otp
 
         seen = []
@@ -983,9 +975,8 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_send_and_verify_otp_resolve_the_sms_channel(
         self, mock_generate_code, mock_dispatch_sms
     ):
-        """The SMS half of the channel registry: the recipient reaches the
-        endpoint under the field name OTP_CHANNELS claims it takes, so a rename
-        in twilio.sms fails here rather than at a caller."""
+        """The SMS half of the registry: the recipient reaches the endpoint
+        under the field name OTP_CHANNELS claims it takes."""
         from telephony.otp import send_otp, verify_otp
 
         mock_dispatch_sms.side_effect = self._log_sent_sms
@@ -1011,8 +1002,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self, mock_generate_code, mock_dispatch_sms
     ):
         """Same per-recipient bucketing as the email case, on the channel whose
-        recipient field differs from it — an unset phone_number would put every
-        number in the shared INVALID_RECIPIENT bucket."""
+        recipient field differs from it."""
         from telephony.otp import send_otp
 
         seen = []
@@ -1037,16 +1027,11 @@ class IntegrationTestTPOTP(IntegrationTestCase):
     def test_send_otp_leaves_form_dict_as_it_found_it(
         self, mock_generate_code, mock_dispatch_email
     ):
-        """form_dict belongs to the caller's request, and send_otp only borrows
-        it to reach the endpoint's rate limiter.
+        """form_dict belongs to the caller's request; send_otp only borrows it
+        to reach the endpoint's rate limiter.
 
-        Left behind, the recipient is PII sitting in a dict frappe writes wholesale
-        into Error Log metadata on any later unhandled exception in the same
-        request — redacted only for credential-looking keys, which 'email' and
-        'phone_number' are not. A caller that posted a document name and nothing
-        else would have leaked that document's contact details on an unrelated
-        failure. It also silently replaced any parameter the caller had under the
-        same name.
+        Left behind, the recipient is PII that frappe writes into Error Log
+        metadata on any later unhandled exception in the same request.
         """
         from telephony.otp import RATE_LIMIT_FIELD, send_otp
 
@@ -1071,8 +1056,7 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         self, mock_generate_code, mock_dispatch_email
     ):
         """frappe's @rate_limit returns early when frappe.request is None, so on
-        a background job — the natural place for an app to dispatch OTPs — the
-        per-recipient cap was not merely wrong but absent."""
+        a background job the cap is not merely wrong but absent."""
         from telephony.otp import send_otp
 
         # frappe.request is an unbound LocalProxy here, not None — falsy, which
@@ -1096,12 +1080,9 @@ class IntegrationTestTPOTP(IntegrationTestCase):
         """A mistyped recipient must fail as a type error, not as an
         AttributeError from inside the rate-limit decorator.
 
-        The normalizers open on ``.strip()``, and send_otp writes its recipient
-        into form_dict verbatim, so an int looked like it would reach one. It
-        does not: @frappe.whitelist validates annotated arguments and is the
-        outermost decorator, so it rejects the int before rate_limit_bucket
-        runs. Pinned here because that ordering is what makes it safe, and
-        nothing else in the file asserts it.
+        @frappe.whitelist is the outermost decorator and validates annotated
+        arguments, so it rejects the int before rate_limit_bucket runs. Pinned
+        because that ordering is what makes it safe.
         """
         from telephony.otp import send_otp
 

--- a/telephony/otp.py
+++ b/telephony/otp.py
@@ -20,11 +20,26 @@ GENERIC_FAILURE = {"verified": False, "reason": "invalid_or_expired"}
 # from the request, so a caller cannot nominate their own bucket.
 RATE_LIMIT_FIELD = "tp_rate_limit_key"
 
+# The caps themselves live here rather than at each decorator, because
+# rate_limit_bucket has to enforce the same numbers itself off the request path
+# (see there). Declared once so the two enforcement points cannot drift apart.
+GENERATE_LIMIT = 5
+VERIFY_LIMIT = 10
+RATE_LIMIT_WINDOW = 10 * 60
+
 # Bucket for any recipient that could not be canonicalized. Neither a valid
 # phone number nor a valid email address, so it can never collide with a real
 # recipient's quota; parking every unusable spelling in one shared bucket is
 # what stops a caller from minting fresh quota by varying the garbage.
 INVALID_RECIPIENT = "invalid"
+
+# The channels an OTP can be delivered over, and where each one's endpoints
+# live. Keys are the values stored in TP OTP.channel, so they are also what
+# other apps name a channel by.
+OTP_CHANNELS = {
+    "SMS": {"module": "telephony.twilio.sms", "recipient_field": "phone_number"},
+    "Email": {"module": "telephony.email_otp", "recipient_field": "email"},
+}
 
 
 _DUMMY_HASH = None
@@ -68,7 +83,43 @@ def clean_purpose(purpose: str) -> str:
     return purpose
 
 
-def rate_limit_bucket(field, normalizer, scope):
+def enforce_rate_limit(bucket, limit, seconds):
+    """Apply the cap ``@rate_limit`` skips when there is no HTTP request.
+
+    ``frappe.rate_limiter.rate_limit`` returns early unless ``frappe.request``
+    is set, so on a background job, the scheduler or a bench console the
+    decorator is inert and the endpoint runs uncapped. That was harmless while
+    the endpoints were reachable only over HTTP, but ``send_otp`` / ``verify_otp``
+    are called from server code — a queued job is the natural place for an app
+    to dispatch OTPs, and it is exactly where the cap would have vanished.
+
+    Counted in its own ``tp-otp-rl:`` namespace rather than the decorator's
+    ``rl:``. The two never both run for one call (this one only fires when the
+    decorator declines to), and sharing a key would mean reproducing frappe's
+    internal key format, which is not ours to depend on.
+
+    ``make_key`` prefixes the site, so the counter is per-site like every other
+    cache entry. The window is opened by the increment that creates the key
+    rather than by a read-then-write: two callers arriving together would both
+    see no key and both reset it, handing out an extra window each time.
+    """
+    key = frappe.cache.make_key(f"tp-otp-rl:{bucket}:{seconds}")
+
+    count = frappe.cache.incrby(key, 1)
+    if count == 1:
+        frappe.cache.expire(key, seconds)
+
+    if count > limit:
+        frappe.throw(
+            _(
+                "You hit the rate limit because of too many requests."
+                " Please try after sometime."
+            ),
+            frappe.RateLimitExceededError,
+        )
+
+
+def rate_limit_bucket(field, normalizer, scope, limit, seconds):
     """Publish a canonical, endpoint-scoped rate-limit key into ``form_dict``.
 
     ``@rate_limit`` cannot be pointed straight at the caller's field, for two
@@ -91,20 +142,36 @@ def rate_limit_bucket(field, normalizer, scope):
     has a non-empty key to work with (with ``ip_based=False`` an empty one makes
     ``rate_limit`` throw its own "Either key or IP flag is required" instead).
 
+    The value is coerced to ``str`` first. The normalizers open on ``.strip()``,
+    and form_dict does not always hold strings: a JSON request body preserves
+    types, and ``call_channel_endpoint`` writes whatever its caller passed. An
+    ``int`` phone number would otherwise raise ``AttributeError`` out of a
+    decorator documented as never throwing, before the endpoint's own validation
+    could reject it cleanly.
+
+    ``limit`` and ``seconds`` must match the ``@rate_limit`` below it, because
+    this enforces them itself on the paths that decorator opts out of — see
+    ``enforce_rate_limit``. Both read the module-level constants so they move
+    together.
+
     Must be applied *above* ``@rate_limit`` so it runs first.
     """
 
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            normalized = normalizer(frappe.form_dict.get(field))
+            normalized = normalizer(frappe.cstr(frappe.form_dict.get(field)))
             # Only rewrite the caller's field if they actually sent it; the
             # bucket is set unconditionally so the limiter is never keyless.
             if field in frappe.form_dict:
                 frappe.form_dict[field] = normalized
-            frappe.form_dict[
-                RATE_LIMIT_FIELD
-            ] = f"{scope}:{normalized or INVALID_RECIPIENT}"
+            bucket = f"{scope}:{normalized or INVALID_RECIPIENT}"
+            frappe.form_dict[RATE_LIMIT_FIELD] = bucket
+
+            # @rate_limit below is inert without a request, so stand in for it.
+            if not frappe.request:
+                enforce_rate_limit(bucket, limit, seconds)
+
             return fn(*args, **kwargs)
 
         return wrapper
@@ -136,16 +203,27 @@ def consume_pending_otps(recipient, channel, purpose, max_attempts) -> int:
     can only arrange for a recipient they are already able to target, so it
     reveals nothing they could not have caused themselves.
     """
-    pending = frappe.get_all(
-        OTP_DOCTYPE,
-        filters={
-            "recipient": recipient,
-            "channel": channel,
-            "purpose": purpose,
-            "is_verified": 0,
-            "expires_at": (">", now_datetime()),
-        },
-        fields=["name", "attempts"],
+    # Locked, like the read in verify_otp_record and for the same reason: this
+    # is a read-modify-write. Two concurrent generates — a double-tapped "resend"
+    # — would otherwise both read the same live rows, both expire them and both
+    # insert, leaving two live OTPs. verify_otp_record only ever reads the newest,
+    # so the code the user was told about first could never verify, while still
+    # spending the newer row's attempt budget.
+    # Through the query builder rather than frappe.get_all, which has no way to
+    # ask for the lock.
+    otp = frappe.qb.DocType(OTP_DOCTYPE)
+    pending = (
+        frappe.qb.from_(otp)
+        .select(otp.name, otp.attempts)
+        .where(
+            (otp.recipient == recipient)
+            & (otp.channel == channel)
+            & (otp.purpose == purpose)
+            & (otp.is_verified == 0)
+            & (otp.expires_at > now_datetime())
+        )
+        .for_update()
+        .run(as_dict=True)
     )
     if not pending:
         return 0
@@ -237,3 +315,123 @@ def verify_otp_record(recipient, channel, otp, purpose, max_attempts):
     otp_doc.save(ignore_permissions=True)
 
     return {"verified": True}
+
+
+# --- Entry points for other apps ------------------------------------------
+#
+# telephony.email_otp and telephony.twilio.sms are the *HTTP* API: one module
+# per channel, each whitelisted, guest-callable and keyed on its own recipient
+# field. An app that verifies a recipient as part of its own document flow has
+# a channel and a recipient rather than a request — and has already run its own
+# permission checks — so it calls send_otp / verify_otp below instead of
+# reaching into a channel module directly.
+
+
+def get_otp_channel(channel: str) -> dict:
+    """Resolve a channel name against OTP_CHANNELS.
+
+    The name selects a module to import, and callers pass it straight through
+    from their own request handlers, so it is never taken on trust.
+    """
+    if channel not in OTP_CHANNELS:
+        frappe.throw(
+            _("{0} is not a supported OTP channel. Use one of: {1}.").format(
+                channel, ", ".join(OTP_CHANNELS)
+            )
+        )
+
+    return OTP_CHANNELS[channel]
+
+
+def call_channel_endpoint(channel: str, method: str, recipient: str, **kwargs):
+    """Call a channel's OTP endpoint the way an HTTP request to it would.
+
+    Those endpoints take their per-recipient rate-limit bucket from
+    ``frappe.form_dict[recipient_field]`` (see ``rate_limit_bucket``), which a
+    server-side caller has no reason to have populated. Left unset it
+    normalizes to ``""``, so every recipient would land in the shared
+    ``INVALID_RECIPIENT`` bucket and share a single site-wide
+    5-per-10-minutes counter: the first five sends in a window would lock out
+    every other recipient, and no recipient would be capped on their own.
+
+    So publish the recipient there first, exactly as the request parser would,
+    and let the endpoint's own normalizer canonicalize it in place.
+
+    Both keys are then put back the way they were found. form_dict belongs to
+    the caller's request, and this is borrowing it:
+
+    - Frappe writes the whole of form_dict into Error Log metadata on any
+      unhandled exception (``get_error_metadata``), redacting only keys that
+      look like credentials — ``email`` and ``phone_number`` are not among them.
+      A caller whose own request never carried the recipient (lending posts a
+      Loan Lead name and a medium, nothing more) would otherwise have that
+      lead's email address or phone number persisted to Error Log by any later,
+      unrelated failure in the same request.
+    - Anything downstream that reads ``form_dict[field]`` — including the
+      caller's own parameter of that name — would otherwise see the OTP
+      recipient in place of what the request actually sent.
+
+    Resolved through ``frappe.get_attr`` at call time rather than imported at
+    module scope, because the channel modules import this one.
+    """
+    config = get_otp_channel(channel)
+    field = config["recipient_field"]
+    endpoint = frappe.get_attr(f"{config['module']}.{method}")
+
+    borrowed = {}
+    for key in (field, RATE_LIMIT_FIELD):
+        if key in frappe.form_dict:
+            borrowed[key] = frappe.form_dict[key]
+
+    frappe.form_dict[field] = recipient
+    try:
+        return endpoint(**{field: recipient}, **kwargs)
+    finally:
+        for key in (field, RATE_LIMIT_FIELD):
+            if key in borrowed:
+                frappe.form_dict[key] = borrowed[key]
+            else:
+                frappe.form_dict.pop(key, None)
+
+
+def send_otp(recipient: str, channel: str, purpose: str = "Verification") -> dict:
+    """Generate an OTP and deliver it to ``recipient`` over ``channel``.
+
+    Returns ``{"sent": True, "expires_in": <seconds>}``. Raises if the channel
+    is not supported or is switched off in TP OTP Settings, the recipient is
+    unusable, the attempt budget for an outstanding code is already spent, the
+    rate limit is hit, or delivery fails — the code itself is never returned, on
+    any path. There is no falsy return: either it sent, or it raised.
+
+    ``purpose`` scopes the OTP: a code is only ever matched against the
+    recipient, channel and purpose it was issued for. Callers verifying a
+    specific record should name it in the purpose, otherwise a code issued for
+    one record verifies any other record sharing that recipient.
+    """
+    return call_channel_endpoint(channel, "generate_otp", recipient, purpose=purpose)
+
+
+def verify_otp(
+    recipient: str, channel: str, otp: str, purpose: str = "Verification"
+) -> dict:
+    """Verify an OTP previously sent to ``recipient`` over ``channel``.
+
+    Returns ``{"verified": True}``, or ``GENERIC_FAILURE`` for a code that is
+    wrong, expired, already used, out of attempts or never issued — the reason
+    is deliberately uniform, see the note on ``GENERIC_FAILURE``.
+
+    A wrong code is a return value, not an exception, and callers must keep it
+    that way: the failed attempt is recorded against the OTP, and that count is
+    what enforces ``otp_max_attempts``. Raising on the result would roll the
+    increment back with the rest of the request and leave the cap toothless.
+
+    A *failed verification* is the only thing that comes back as a value. The
+    call still raises for anything that is not an attempt at all: an unsupported
+    channel, a channel switched off in TP OTP Settings, a recipient that is not
+    a usable address or number, or the rate limit. Callers must handle both —
+    treating a raise as "wrong code" reports a misconfigured channel to the user
+    as a failed OTP.
+    """
+    return call_channel_endpoint(
+        channel, "verify_otp", recipient, otp=otp, purpose=purpose
+    )

--- a/telephony/otp.py
+++ b/telephony/otp.py
@@ -20,9 +20,8 @@ GENERIC_FAILURE = {"verified": False, "reason": "invalid_or_expired"}
 # from the request, so a caller cannot nominate their own bucket.
 RATE_LIMIT_FIELD = "tp_rate_limit_key"
 
-# The caps themselves live here rather than at each decorator, because
-# rate_limit_bucket has to enforce the same numbers itself off the request path
-# (see there). Declared once so the two enforcement points cannot drift apart.
+# Declared once: rate_limit_bucket enforces the same numbers itself off the
+# request path, so the two enforcement points must not drift apart.
 GENERATE_LIMIT = 5
 VERIFY_LIMIT = 10
 RATE_LIMIT_WINDOW = 10 * 60
@@ -33,9 +32,8 @@ RATE_LIMIT_WINDOW = 10 * 60
 # what stops a caller from minting fresh quota by varying the garbage.
 INVALID_RECIPIENT = "invalid"
 
-# The channels an OTP can be delivered over, and where each one's endpoints
-# live. Keys are the values stored in TP OTP.channel, so they are also what
-# other apps name a channel by.
+# Keys are the values stored in TP OTP.channel, so they are also what other
+# apps name a channel by.
 OTP_CHANNELS = {
     "SMS": {"module": "telephony.twilio.sms", "recipient_field": "phone_number"},
     "Email": {"module": "telephony.email_otp", "recipient_field": "email"},
@@ -86,22 +84,8 @@ def clean_purpose(purpose: str) -> str:
 def enforce_rate_limit(bucket, limit, seconds):
     """Apply the cap ``@rate_limit`` skips when there is no HTTP request.
 
-    ``frappe.rate_limiter.rate_limit`` returns early unless ``frappe.request``
-    is set, so on a background job, the scheduler or a bench console the
-    decorator is inert and the endpoint runs uncapped. That was harmless while
-    the endpoints were reachable only over HTTP, but ``send_otp`` / ``verify_otp``
-    are called from server code — a queued job is the natural place for an app
-    to dispatch OTPs, and it is exactly where the cap would have vanished.
-
-    Counted in its own ``tp-otp-rl:`` namespace rather than the decorator's
-    ``rl:``. The two never both run for one call (this one only fires when the
-    decorator declines to), and sharing a key would mean reproducing frappe's
-    internal key format, which is not ours to depend on.
-
-    ``make_key`` prefixes the site, so the counter is per-site like every other
-    cache entry. The window is opened by the increment that creates the key
-    rather than by a read-then-write: two callers arriving together would both
-    see no key and both reset it, handing out an extra window each time.
+    Its own ``tp-otp-rl:`` namespace, since the decorator's key format is not
+    ours to depend on; only ever runs when the decorator declines to.
     """
     key = frappe.cache.make_key(f"tp-otp-rl:{bucket}:{seconds}")
 
@@ -142,17 +126,11 @@ def rate_limit_bucket(field, normalizer, scope, limit, seconds):
     has a non-empty key to work with (with ``ip_based=False`` an empty one makes
     ``rate_limit`` throw its own "Either key or IP flag is required" instead).
 
-    The value is coerced to ``str`` first. The normalizers open on ``.strip()``,
-    and form_dict does not always hold strings: a JSON request body preserves
-    types, and ``call_channel_endpoint`` writes whatever its caller passed. An
-    ``int`` phone number would otherwise raise ``AttributeError`` out of a
-    decorator documented as never throwing, before the endpoint's own validation
-    could reject it cleanly.
+    The value is coerced to ``str`` first: form_dict does not always hold
+    strings, and the normalizers open on ``.strip()``.
 
-    ``limit`` and ``seconds`` must match the ``@rate_limit`` below it, because
-    this enforces them itself on the paths that decorator opts out of — see
-    ``enforce_rate_limit``. Both read the module-level constants so they move
-    together.
+    ``limit`` and ``seconds`` must match the ``@rate_limit`` below it — this
+    enforces them itself on the paths that decorator opts out of.
 
     Must be applied *above* ``@rate_limit`` so it runs first.
     """
@@ -203,14 +181,10 @@ def consume_pending_otps(recipient, channel, purpose, max_attempts) -> int:
     can only arrange for a recipient they are already able to target, so it
     reveals nothing they could not have caused themselves.
     """
-    # Locked, like the read in verify_otp_record and for the same reason: this
-    # is a read-modify-write. Two concurrent generates — a double-tapped "resend"
-    # — would otherwise both read the same live rows, both expire them and both
-    # insert, leaving two live OTPs. verify_otp_record only ever reads the newest,
-    # so the code the user was told about first could never verify, while still
-    # spending the newer row's attempt budget.
-    # Through the query builder rather than frappe.get_all, which has no way to
-    # ask for the lock.
+    # Locked, like the read in verify_otp_record: this is a read-modify-write,
+    # and two concurrent generates would otherwise leave two live OTPs, of which
+    # only the newest can ever verify. Query builder because frappe.get_all has
+    # no way to ask for the lock.
     otp = frappe.qb.DocType(OTP_DOCTYPE)
     pending = (
         frappe.qb.from_(otp)
@@ -319,19 +293,15 @@ def verify_otp_record(recipient, channel, otp, purpose, max_attempts):
 
 # --- Entry points for other apps ------------------------------------------
 #
-# telephony.email_otp and telephony.twilio.sms are the *HTTP* API: one module
-# per channel, each whitelisted, guest-callable and keyed on its own recipient
-# field. An app that verifies a recipient as part of its own document flow has
-# a channel and a recipient rather than a request — and has already run its own
-# permission checks — so it calls send_otp / verify_otp below instead of
-# reaching into a channel module directly.
+# telephony.email_otp and telephony.twilio.sms are the *HTTP* API. Server-side
+# callers, which have a channel and a recipient rather than a request, use
+# send_otp / verify_otp below instead of reaching into a channel module.
 
 
 def get_otp_channel(channel: str) -> dict:
     """Resolve a channel name against OTP_CHANNELS.
 
-    The name selects a module to import, and callers pass it straight through
-    from their own request handlers, so it is never taken on trust.
+    The name selects a module to import, so it is never taken on trust.
     """
     if channel not in OTP_CHANNELS:
         frappe.throw(
@@ -346,33 +316,11 @@ def get_otp_channel(channel: str) -> dict:
 def call_channel_endpoint(channel: str, method: str, recipient: str, **kwargs):
     """Call a channel's OTP endpoint the way an HTTP request to it would.
 
-    Those endpoints take their per-recipient rate-limit bucket from
-    ``frappe.form_dict[recipient_field]`` (see ``rate_limit_bucket``), which a
-    server-side caller has no reason to have populated. Left unset it
-    normalizes to ``""``, so every recipient would land in the shared
-    ``INVALID_RECIPIENT`` bucket and share a single site-wide
-    5-per-10-minutes counter: the first five sends in a window would lock out
-    every other recipient, and no recipient would be capped on their own.
-
-    So publish the recipient there first, exactly as the request parser would,
-    and let the endpoint's own normalizer canonicalize it in place.
-
-    Both keys are then put back the way they were found. form_dict belongs to
-    the caller's request, and this is borrowing it:
-
-    - Frappe writes the whole of form_dict into Error Log metadata on any
-      unhandled exception (``get_error_metadata``), redacting only keys that
-      look like credentials — ``email`` and ``phone_number`` are not among them.
-      A caller whose own request never carried the recipient (lending posts a
-      Loan Lead name and a medium, nothing more) would otherwise have that
-      lead's email address or phone number persisted to Error Log by any later,
-      unrelated failure in the same request.
-    - Anything downstream that reads ``form_dict[field]`` — including the
-      caller's own parameter of that name — would otherwise see the OTP
-      recipient in place of what the request actually sent.
-
-    Resolved through ``frappe.get_attr`` at call time rather than imported at
-    module scope, because the channel modules import this one.
+    The endpoints take their per-recipient rate-limit bucket from
+    ``frappe.form_dict[recipient_field]``, which a server-side caller has not
+    populated, so publish the recipient there first — then put form_dict back
+    the way it was found: it belongs to the caller's request, and frappe writes
+    it wholesale into Error Log metadata on any later unhandled exception.
     """
     config = get_otp_channel(channel)
     field = config["recipient_field"]
@@ -397,16 +345,12 @@ def call_channel_endpoint(channel: str, method: str, recipient: str, **kwargs):
 def send_otp(recipient: str, channel: str, purpose: str = "Verification") -> dict:
     """Generate an OTP and deliver it to ``recipient`` over ``channel``.
 
-    Returns ``{"sent": True, "expires_in": <seconds>}``. Raises if the channel
-    is not supported or is switched off in TP OTP Settings, the recipient is
-    unusable, the attempt budget for an outstanding code is already spent, the
-    rate limit is hit, or delivery fails — the code itself is never returned, on
-    any path. There is no falsy return: either it sent, or it raised.
+    Returns ``{"sent": True, "expires_in": <seconds>}``, or raises. The code
+    itself is never returned, on any path.
 
-    ``purpose`` scopes the OTP: a code is only ever matched against the
-    recipient, channel and purpose it was issued for. Callers verifying a
-    specific record should name it in the purpose, otherwise a code issued for
-    one record verifies any other record sharing that recipient.
+    ``purpose`` scopes the OTP — a code only matches the recipient, channel and
+    purpose it was issued for, so callers verifying a specific record should
+    name that record in the purpose.
     """
     return call_channel_endpoint(channel, "generate_otp", recipient, purpose=purpose)
 
@@ -416,21 +360,13 @@ def verify_otp(
 ) -> dict:
     """Verify an OTP previously sent to ``recipient`` over ``channel``.
 
-    Returns ``{"verified": True}``, or ``GENERIC_FAILURE`` for a code that is
-    wrong, expired, already used, out of attempts or never issued — the reason
-    is deliberately uniform, see the note on ``GENERIC_FAILURE``.
+    A failed verification is the only thing returned as a value
+    (``GENERIC_FAILURE``); an unsupported or disabled channel, an unusable
+    recipient and the rate limit all raise, so callers must handle both.
 
-    A wrong code is a return value, not an exception, and callers must keep it
-    that way: the failed attempt is recorded against the OTP, and that count is
-    what enforces ``otp_max_attempts``. Raising on the result would roll the
-    increment back with the rest of the request and leave the cap toothless.
-
-    A *failed verification* is the only thing that comes back as a value. The
-    call still raises for anything that is not an attempt at all: an unsupported
-    channel, a channel switched off in TP OTP Settings, a recipient that is not
-    a usable address or number, or the rate limit. Callers must handle both —
-    treating a raise as "wrong code" reports a misconfigured channel to the user
-    as a failed OTP.
+    Callers must not raise on a failure result either: the failed attempt is
+    recorded against the OTP, and rolling that increment back with the request
+    would leave ``otp_max_attempts`` toothless.
     """
     return call_channel_endpoint(
         channel, "verify_otp", recipient, otp=otp, purpose=purpose

--- a/telephony/otp.py
+++ b/telephony/otp.py
@@ -10,30 +10,24 @@ OTP_DOCTYPE = "TP OTP"
 
 MAX_PURPOSE_LENGTH = 140
 
-# Guest-facing verification failures are deliberately indistinguishable from
-# one another. Reporting "no such OTP" separately from "wrong code" lets an
-# unauthenticated caller enumerate which recipients have a pending OTP and
-# what state it is in.
+# Uniform on purpose: separate reasons would let a guest enumerate which
+# recipients have a pending OTP.
 GENERIC_FAILURE = {"verified": False, "reason": "invalid_or_expired"}
 
-# The form_dict field @rate_limit is pointed at. Always overwritten, never read
-# from the request, so a caller cannot nominate their own bucket.
+# Always overwritten, never read from the request, so a caller cannot
+# nominate their own bucket.
 RATE_LIMIT_FIELD = "tp_rate_limit_key"
 
-# Declared once: rate_limit_bucket enforces the same numbers itself off the
-# request path, so the two enforcement points must not drift apart.
+# Shared by @rate_limit and rate_limit_bucket's own off-request enforcement.
 GENERATE_LIMIT = 5
 VERIFY_LIMIT = 10
 RATE_LIMIT_WINDOW = 10 * 60
 
-# Bucket for any recipient that could not be canonicalized. Neither a valid
-# phone number nor a valid email address, so it can never collide with a real
-# recipient's quota; parking every unusable spelling in one shared bucket is
-# what stops a caller from minting fresh quota by varying the garbage.
+# One shared bucket for every uncanonicalizable recipient, so varying the
+# garbage cannot mint fresh quota. Collides with no real recipient.
 INVALID_RECIPIENT = "invalid"
 
-# Keys are the values stored in TP OTP.channel, so they are also what other
-# apps name a channel by.
+# Keys are the values stored in TP OTP.channel.
 OTP_CHANNELS = {
     "SMS": {"module": "telephony.twilio.sms", "recipient_field": "phone_number"},
     "Email": {"module": "telephony.email_otp", "recipient_field": "email"},
@@ -48,17 +42,8 @@ def generate_otp_code(length: int) -> str:
 
 
 def equalize_verify_cost():
-    """Spend a KDF round on the paths that never reach a real comparison.
-
-    GENERIC_FAILURE makes every failure look alike in the *body*, but not in
-    the clock: only the wrong-code path runs pbkdf2 (~29k rounds), so without
-    this a guest can tell "no live OTP for this recipient" from "there is one"
-    purely by response latency — recovering what the generic reason hides.
-
-    This does not make verification constant-time: the wrong-code path also
-    writes the incremented attempt count, which the others do not. It closes
-    the KDF-sized gap, which is the part big enough to measure over a network.
-    """
+    """Spend a KDF round on the paths that never reach a real comparison, so
+    latency does not leak what GENERIC_FAILURE hides. Not constant-time."""
     global _DUMMY_HASH
 
     from passlib.hash import pbkdf2_sha256
@@ -82,11 +67,7 @@ def clean_purpose(purpose: str) -> str:
 
 
 def enforce_rate_limit(bucket, limit, seconds):
-    """Apply the cap ``@rate_limit`` skips when there is no HTTP request.
-
-    Its own ``tp-otp-rl:`` namespace, since the decorator's key format is not
-    ours to depend on; only ever runs when the decorator declines to.
-    """
+    """Apply the cap ``@rate_limit`` skips when there is no HTTP request."""
     key = frappe.cache.make_key(f"tp-otp-rl:{bucket}:{seconds}")
 
     count = frappe.cache.incrby(key, 1)
@@ -104,43 +85,15 @@ def enforce_rate_limit(bucket, limit, seconds):
 
 
 def rate_limit_bucket(field, normalizer, scope, limit, seconds):
-    """Publish a canonical, endpoint-scoped rate-limit key into ``form_dict``.
-
-    ``@rate_limit`` cannot be pointed straight at the caller's field, for two
-    independent reasons:
-
-    1. It buckets on ``frappe.form_dict[key]`` verbatim, so ``+911234500001``,
-       ``+91 1234500001`` and ``+91-1234500001`` are three buckets for one
-       recipient — a formatting loop would walk straight past the send cap.
-    2. Its cache key is ``rl:{form_dict.cmd}:{identity}:{seconds}``, and only
-       ``/api/v1`` populates ``cmd``. Over ``/api/v2`` it renders as ``None``,
-       so two endpoints sharing a key field and a window collide on a single
-       counter — failed verifies would eat the resend quota and vice versa.
-
-    So normalize the value, qualify it with a per-endpoint ``scope``, and point
-    ``@rate_limit`` at the field written here instead of at the raw one.
-
-    ``normalizer`` runs on unvalidated input and must not throw. Anything it
-    cannot canonicalize lands in the shared ``INVALID_RECIPIENT`` bucket — the
-    endpoint's own validation rejects it a moment later, and the limiter still
-    has a non-empty key to work with (with ``ip_based=False`` an empty one makes
-    ``rate_limit`` throw its own "Either key or IP flag is required" instead).
-
-    The value is coerced to ``str`` first: form_dict does not always hold
-    strings, and the normalizers open on ``.strip()``.
-
-    ``limit`` and ``seconds`` must match the ``@rate_limit`` below it — this
-    enforces them itself on the paths that decorator opts out of.
-
-    Must be applied *above* ``@rate_limit`` so it runs first.
-    """
+    """Publish a canonical, endpoint-scoped rate-limit key into ``form_dict``:
+    ``@rate_limit`` buckets on the raw value and its own key collides across
+    endpoints. Apply above it, with matching ``limit``/``seconds``."""
 
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             normalized = normalizer(frappe.cstr(frappe.form_dict.get(field)))
-            # Only rewrite the caller's field if they actually sent it; the
-            # bucket is set unconditionally so the limiter is never keyless.
+            # Bucket set unconditionally so the limiter is never keyless.
             if field in frappe.form_dict:
                 frappe.form_dict[field] = normalized
             bucket = f"{scope}:{normalized or INVALID_RECIPIENT}"
@@ -159,32 +112,10 @@ def rate_limit_bucket(field, normalizer, scope, limit, seconds):
 
 def consume_pending_otps(recipient, channel, purpose, max_attempts) -> int:
     """Expire outstanding OTPs for this recipient and return attempts already
-    spent against them.
-
-    ``verify_otp_record`` only ever reads the newest unverified row, and
-    ``attempts`` lives on that row. Without carrying the count forward, each
-    ``generate_otp`` call would hand out a fresh ``otp_max_attempts`` budget
-    against the same short code space. Carrying forward only from *live* rows
-    means the budget still resets naturally once the window lapses.
-
-    Once that carried budget is spent, refuse rather than issue another code.
-    The new row would start at the cap *and* carry a fresh ``expires_at``, so
-    each resend pushed the lockout a full window further out while billing for
-    a code that could never verify — a user who responds to being locked out by
-    retrying, which is the normal response, kept themselves locked out forever.
-    Refusing leaves the live row's expiry untouched, so the lockout drains on
-    its own no matter how often it is retried.
-
-    This does make "locked out" distinguishable from "not", unlike the uniform
-    GENERIC_FAILURE on the verify side. That is accepted: reaching this state
-    requires ``max_attempts`` failed verifies against a live OTP, which a caller
-    can only arrange for a recipient they are already able to target, so it
-    reveals nothing they could not have caused themselves.
-    """
-    # Locked, like the read in verify_otp_record: this is a read-modify-write,
-    # and two concurrent generates would otherwise leave two live OTPs, of which
-    # only the newest can ever verify. Query builder because frappe.get_all has
-    # no way to ask for the lock.
+    spent, so a resend cannot mint a fresh budget. Once it is spent, refuse
+    rather than issue a code that would push the lockout further out."""
+    # Locked: two concurrent generates would otherwise leave two live OTPs, of
+    # which only the newest can verify. Query builder, for for_update().
     otp = frappe.qb.DocType(OTP_DOCTYPE)
     pending = (
         frappe.qb.from_(otp)
@@ -266,9 +197,8 @@ def verify_otp_record(recipient, channel, otp, purpose, max_attempts):
         equalize_verify_cost()
         return dict(GENERIC_FAILURE)
 
-    # Locked: reading and incrementing `attempts` is a read-modify-write, so
-    # concurrent verifies would otherwise share a stale count and collectively
-    # exceed otp_max_attempts.
+    # Locked: concurrent verifies would otherwise share a stale `attempts`
+    # count and collectively exceed otp_max_attempts.
     otp_doc = frappe.get_doc(OTP_DOCTYPE, otp_name, for_update=True)
 
     if get_datetime(otp_doc.expires_at) < now_datetime():
@@ -293,16 +223,13 @@ def verify_otp_record(recipient, channel, otp, purpose, max_attempts):
 
 # --- Entry points for other apps ------------------------------------------
 #
-# telephony.email_otp and telephony.twilio.sms are the *HTTP* API. Server-side
-# callers, which have a channel and a recipient rather than a request, use
-# send_otp / verify_otp below instead of reaching into a channel module.
+# telephony.email_otp and telephony.twilio.sms are the HTTP API; server-side
+# callers use send_otp / verify_otp instead of reaching into a channel module.
 
 
 def get_otp_channel(channel: str) -> dict:
-    """Resolve a channel name against OTP_CHANNELS.
-
-    The name selects a module to import, so it is never taken on trust.
-    """
+    """Resolve a channel name against OTP_CHANNELS. The name selects a module
+    to import, so it is never taken on trust."""
     if channel not in OTP_CHANNELS:
         frappe.throw(
             _("{0} is not a supported OTP channel. Use one of: {1}.").format(
@@ -314,14 +241,9 @@ def get_otp_channel(channel: str) -> dict:
 
 
 def call_channel_endpoint(channel: str, method: str, recipient: str, **kwargs):
-    """Call a channel's OTP endpoint the way an HTTP request to it would.
-
-    The endpoints take their per-recipient rate-limit bucket from
-    ``frappe.form_dict[recipient_field]``, which a server-side caller has not
-    populated, so publish the recipient there first — then put form_dict back
-    the way it was found: it belongs to the caller's request, and frappe writes
-    it wholesale into Error Log metadata on any later unhandled exception.
-    """
+    """Call a channel's OTP endpoint the way an HTTP request would: they bucket
+    their rate limit on ``form_dict[recipient_field]``, so publish the recipient
+    there, then restore form_dict — it belongs to the caller's request."""
     config = get_otp_channel(channel)
     field = config["recipient_field"]
     endpoint = frappe.get_attr(f"{config['module']}.{method}")
@@ -343,31 +265,19 @@ def call_channel_endpoint(channel: str, method: str, recipient: str, **kwargs):
 
 
 def send_otp(recipient: str, channel: str, purpose: str = "Verification") -> dict:
-    """Generate an OTP and deliver it to ``recipient`` over ``channel``.
-
-    Returns ``{"sent": True, "expires_in": <seconds>}``, or raises. The code
-    itself is never returned, on any path.
-
-    ``purpose`` scopes the OTP — a code only matches the recipient, channel and
-    purpose it was issued for, so callers verifying a specific record should
-    name that record in the purpose.
-    """
+    """Generate an OTP and deliver it to ``recipient`` over ``channel``; the
+    code is never returned. ``purpose`` scopes the OTP, so callers verifying a
+    specific record should name that record in it."""
     return call_channel_endpoint(channel, "generate_otp", recipient, purpose=purpose)
 
 
 def verify_otp(
     recipient: str, channel: str, otp: str, purpose: str = "Verification"
 ) -> dict:
-    """Verify an OTP previously sent to ``recipient`` over ``channel``.
-
-    A failed verification is the only thing returned as a value
-    (``GENERIC_FAILURE``); an unsupported or disabled channel, an unusable
-    recipient and the rate limit all raise, so callers must handle both.
-
-    Callers must not raise on a failure result either: the failed attempt is
-    recorded against the OTP, and rolling that increment back with the request
-    would leave ``otp_max_attempts`` toothless.
-    """
+    """Verify an OTP previously sent to ``recipient`` over ``channel``. A failed
+    verification is the only thing returned as a value — a bad channel, an
+    unusable recipient and the rate limit all raise — and callers must not turn
+    that value into a raise, which would roll back the recorded attempt."""
     return call_channel_endpoint(
         channel, "verify_otp", recipient, otp=otp, purpose=purpose
     )

--- a/telephony/twilio/sms.py
+++ b/telephony/twilio/sms.py
@@ -18,15 +18,14 @@ from telephony.otp import (
 
 from .twilio_handler import Twilio
 
-# TP SMS Log is readable by TP Agent and retained for 90 days, so writing the
-# rendered OTP body there would undo hashing the code in TP OTP. Keep the
-# routing metadata (to/from/sid/status) and drop the body.
+# TP SMS Log is agent-readable and kept 90 days, so the OTP body is dropped
+# and only the routing metadata is logged.
 REDACTED_MESSAGE = "[redacted]"
 
 ASCII_DIGITS = frozenset("0123456789")
 
-# Punctuation people actually type into phone numbers. Anything outside this and
-# ASCII_DIGITS makes the input a rejection rather than something to clean up.
+# Anything outside this and ASCII_DIGITS is a rejection, not something to
+# clean up.
 PHONE_SEPARATORS = frozenset(" -().")
 
 # Stand-in for "no cap" when send_sms_rate_limit_per_hour is explicitly 0.
@@ -37,32 +36,10 @@ DEFAULT_SEND_SMS_LIMIT = 60
 
 
 def clean_phone_number(phone_number: str) -> str:
-    """Canonicalize to a single E.164-shaped string: ``+`` then ASCII digits.
-
-    Every spelling of one number has to collapse to one string, because this
-    value is both the ``TP OTP.recipient`` lookup key and the rate-limit
-    bucket. Keeping the caller's ``+`` verbatim was not enough: ``91…`` and
-    ``+91…`` stayed distinct, so one number still had two OTP rows and two
-    quotas. Digits are extracted and a single ``+`` is re-attached, so all of
-    ``+91 79-7739 6938``, ``917977396938`` and ``+917977396938`` agree.
-
-    Anything that is not a digit or ordinary phone punctuation is a *rejection*,
-    not something to strip. Discarding unexpected characters silently turns one
-    number into a different, deliverable one: ``"1. +919876543210"`` used to
-    yield ``+1919876543210``, a live US number, so the OTP went to a stranger.
-    Non-ASCII digits are rejected for the same reason and one more — they are
-    true under ``str.isdigit()``, and MariaDB's default ``utf8mb4_unicode_ci``
-    collation compares them equal to their ASCII form, so keeping them would let
-    a caller land on another recipient's row while holding a bucket of their own.
-
-    Leading ``+`` signs are the one thing dropped rather than rejected, so a
-    doubled ``++91…`` typo still resolves instead of failing a verification the
-    user has no way to diagnose.
-
-    No country code is inferred: telephony is a library and the caller's
-    dialling context is unknown, so a national-format number stays national
-    and Twilio rejects it, exactly as before.
-    """
+    """Canonicalize to one E.164-shaped string, since this is both the
+    ``TP OTP.recipient`` key and the rate-limit bucket. Unexpected characters
+    are rejected, never stripped: dropping them rewrites one number into
+    another, deliverable one. No country code is inferred."""
     digits = []
     for char in (phone_number or "").strip().lstrip("+"):
         if char in ASCII_DIGITS:
@@ -83,14 +60,8 @@ def get_sms_settings():
 
 def build_sms_log(to, from_number, message, purpose, status, sid=None, error=None):
     """Build the TP SMS Log payload, with the body redacted for OTP traffic.
-
-    Shared by both dispatch paths so the redaction cannot drift between them:
-    the failure path routes its row through Redis, and the rendered code must
-    not be sitting in a queue payload either.
-
-    ``sent_at`` is a string, not a datetime — this dict has to survive
-    ``json.dumps`` on the deferred path.
-    """
+    ``sent_at`` is a string, not a datetime: this dict has to survive
+    ``json.dumps`` on the deferred path."""
     return {
         "doctype": "TP SMS Log",
         "to": to,
@@ -118,18 +89,14 @@ def dispatch_sms(to, message, purpose="General"):
     settings = get_sms_settings()
 
     to = clean_phone_number(to)
-    # `to` and `message` are both mandatory on TP SMS Log, so an empty one would
-    # make the failure path's *own* audit write fail — losing the Failed row and
-    # masking the real error behind a MandatoryError. Reject up front, where
-    # there is still a caller to tell and no credential has been decrypted yet.
+    # Both are mandatory on TP SMS Log, so an empty one would make the failure
+    # path's own audit write fail and mask the real error. Reject up front.
     if not to:
         frappe.throw(_("Please provide a valid phone number."))
     if not message:
         frappe.throw(_("Cannot send an empty SMS."))
 
-    # NOTE: connect() reads TP Twilio Settings from cache, but Twilio.__init__
-    # still decrypts api_secret and get_twilio_client() re-fetches the Single
-    # uncached to decrypt auth_token — two KDF rounds plus a query per SMS.
+    # NOTE: two KDF rounds plus an uncached query per SMS, inside connect().
     twilio = Twilio.connect()
     if not twilio:
         frappe.throw(_("Please enable and configure TP Twilio Settings to send SMS."))
@@ -141,30 +108,21 @@ def dispatch_sms(to, message, purpose="General"):
             to=to, from_=from_number, body=message
         )
     except Exception as e:
-        # Deferred through Redis, not committed. The Failed row is this attempt's
-        # audit trail and has to outlive the frappe.throw below, but a
-        # frappe.db.commit() here would also commit whatever the *caller* had
-        # pending: called from a doc hook, an unrelated Twilio outage would
-        # persist that hook's half-finished writes while the request aborted.
-        # deferred_insert parks the row in Redis and the scheduler inserts it in
-        # a transaction of its own, so neither side can drag the other along.
+        # Deferred, not committed: the Failed row must outlive the throw below,
+        # but a commit here would also persist the caller's pending writes.
         deferred_insert(
             "TP SMS Log",
             [build_sms_log(to, from_number, message, purpose, "Failed", error=str(e))],
         )
-        # Pass an explicit message: with none, log_error falls back to
-        # get_traceback(with_context=True), which renders every frame's locals
-        # into Error Log — including `message`, the rendered OTP body, and the
-        # decrypted api_secret held by twilio's own client frames. That would
-        # leak in cleartext exactly what is redacted and encrypted elsewhere.
-        # Deferred for the same reason as the row above.
+        # Explicit message: without one, log_error renders every frame's locals
+        # into Error Log — the OTP body and the decrypted api_secret included.
         frappe.log_error(
             title="Failed to send SMS via Twilio",
             message=f"to={to} error={type(e).__name__}: {e}",
             defer_insert=True,
         )
-        # The raw Twilio error carries account SIDs, the configured from-number
-        # and endpoint URLs; generate_otp is guest-callable, so keep it out.
+        # The raw Twilio error carries account SIDs and the from-number, and
+        # generate_otp is guest-callable.
         frappe.throw(_("Could not send the SMS. Please try again later."))
 
     return create_sms_log(
@@ -173,38 +131,25 @@ def dispatch_sms(to, message, purpose="General"):
 
 
 def get_send_sms_limit():
-    """Per-hour cap for send_sms, read at request time.
-
-    A hardcoded number would either be too low for a site doing bulk
-    notifications or too high to protect the Twilio balance of one that isn't,
-    so this is configurable, with 0 meaning no limit. ``rate_limit`` accepts a
-    callable for exactly this.
-    """
+    """Per-hour cap for send_sms, read at request time. 0 means no limit."""
     limit = frappe.get_cached_value(
         "TP OTP Settings", "TP OTP Settings", "send_sms_rate_limit_per_hour"
     )
 
-    # None is not 0. A Single holds no value for a field until the doc is first
-    # saved, so on an existing site this reads None until someone opens the
-    # form — treating that as "unlimited" would silently leave every such site
-    # uncapped. Only an explicit 0 opts out.
+    # None is not 0: a Single holds no value until first saved, and treating
+    # that as "unlimited" would leave every such site uncapped.
     if limit is None:
         return DEFAULT_SEND_SMS_LIMIT
 
-    # The limiter has no "unlimited", so use a ceiling no single client will
-    # reach within one window.
+    # The limiter has no "unlimited", so use an unreachable ceiling.
     return limit or UNLIMITED_SENDS
 
 
 @frappe.whitelist(methods=["POST"])
 @rate_limit(limit=get_send_sms_limit, seconds=60 * 60)
 def send_sms(to: str, message: str):
-    """Send a plain SMS. Restricted to telephony agents/managers.
-
-    Unlike the OTP endpoints this is rate limited per client rather than per
-    recipient: the risk here is total spend on arbitrary numbers, not repeated
-    hammering of one number.
-    """
+    """Send a plain SMS. Rate limited per client rather than per recipient:
+    the risk here is total spend, not hammering of one number."""
     # Defer to the DocType's permissions so the role set stays configurable.
     frappe.has_permission("TP SMS Log", "create", throw=True)
 
@@ -212,10 +157,8 @@ def send_sms(to: str, message: str):
     return {"name": log.name, "status": log.status}
 
 
-# ip_based=False: the default mixes the client IP into the identity, making this
-# a per-(IP, recipient) cap rather than the per-recipient one it is documented
-# as. Rotating IPs would then buy unlimited SMS to a single number, and the
-# Twilio bill with it.
+# ip_based=False: the default mixes in the client IP, so rotating IPs would
+# buy unlimited SMS to a single number.
 @frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep
 @rate_limit_bucket(
     "phone_number",
@@ -246,8 +189,7 @@ def generate_otp(phone_number: str, purpose: str = "Verification"):
     )
 
     # Record first, so a user can never hold a code with no record to verify
-    # against. The failure path in dispatch_sms no longer commits, so a send
-    # failure rolls this record back with the rest of the request.
+    # against; a send failure rolls this back with the rest of the request.
     otp_doc = create_otp_record(
         phone_number,
         "SMS",

--- a/telephony/twilio/sms.py
+++ b/telephony/twilio/sms.py
@@ -5,7 +5,10 @@ from frappe.rate_limiter import rate_limit
 from frappe.utils import now
 
 from telephony.otp import (
+    GENERATE_LIMIT,
     RATE_LIMIT_FIELD,
+    RATE_LIMIT_WINDOW,
+    VERIFY_LIMIT,
     clean_purpose,
     create_otp_record,
     generate_otp_code,
@@ -214,8 +217,19 @@ def send_sms(to: str, message: str):
 # as. Rotating IPs would then buy unlimited SMS to a single number, and the
 # Twilio bill with it.
 @frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep
-@rate_limit_bucket("phone_number", clean_phone_number, "sms:generate")
-@rate_limit(key=RATE_LIMIT_FIELD, limit=5, seconds=10 * 60, ip_based=False)
+@rate_limit_bucket(
+    "phone_number",
+    clean_phone_number,
+    "sms:generate",
+    GENERATE_LIMIT,
+    RATE_LIMIT_WINDOW,
+)
+@rate_limit(
+    key=RATE_LIMIT_FIELD,
+    limit=GENERATE_LIMIT,
+    seconds=RATE_LIMIT_WINDOW,
+    ip_based=False,
+)
 def generate_otp(phone_number: str, purpose: str = "Verification"):
     """Generate an OTP and send it over SMS to the given phone number."""
     settings = get_sms_settings()
@@ -249,8 +263,12 @@ def generate_otp(phone_number: str, purpose: str = "Verification"):
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])  # nosemgrep
-@rate_limit_bucket("phone_number", clean_phone_number, "sms:verify")
-@rate_limit(key=RATE_LIMIT_FIELD, limit=10, seconds=10 * 60, ip_based=False)
+@rate_limit_bucket(
+    "phone_number", clean_phone_number, "sms:verify", VERIFY_LIMIT, RATE_LIMIT_WINDOW
+)
+@rate_limit(
+    key=RATE_LIMIT_FIELD, limit=VERIFY_LIMIT, seconds=RATE_LIMIT_WINDOW, ip_based=False
+)
 def verify_otp(phone_number: str, otp: str, purpose: str = "Verification"):
     """Verify an OTP previously sent to the given phone number."""
     settings = get_sms_settings()


### PR DESCRIPTION
telephony.email_otp and telephony.twilio.sms are the HTTP API: one module per channel, each whitelisted, guest-callable and keyed on its own recipient field. An app that verifies a recipient as part of its own document flow has a channel and a recipient rather than a request, and has already run its own permission checks, so it has nowhere to call. It ends up reaching into a channel module directly, duplicating telephony's internals at every caller.

Adds OTP_CHANNELS plus send_otp/verify_otp, which take a channel by name and resolve it against that registry. The name selects a module to import and callers pass it through from their own request handlers, so it is validated before it reaches frappe.get_attr, never taken on trust. The wrappers are deliberately not whitelisted: they skip CSRF, guest gating and POST-only enforcement because they are not reachable over HTTP at all.

Three things the endpoints assumed a request for, which had to be handled before a server-side caller could use them:

- They take their per-recipient rate-limit bucket from frappe.form_dict[recipient_field], which the request parser populates and a server-side caller does not. Left unset it normalizes to "", so every recipient landed in the shared INVALID_RECIPIENT bucket and shared one site-wide counter: five sends would lock out every other recipient, and none would be capped on their own. call_channel_endpoint publishes the recipient there first, then puts form_dict back the way it found it -- frappe writes the whole of form_dict into Error Log metadata on any unhandled exception, redacting only credential-looking keys, so a caller that posted a document name and nothing else would otherwise have leaked that document's email address or phone number on any later, unrelated failure in the same request.

- frappe's @rate_limit returns early unless frappe.request is set, so off the request path the cap was not merely wrong but absent, and a queued job is the natural place for an app to dispatch OTPs. rate_limit_bucket now enforces the same numbers itself whenever the decorator declines to. The caps move to module-level constants so the two enforcement points cannot drift apart.

- The normalizers open on .strip() and form_dict does not always hold strings. The value is coerced first, so the decorator documented as never throwing cannot raise AttributeError ahead of the endpoint's own validation.

Also: lock the pending rows in consume_pending_otps, like the read in verify_otp_record and for the same reason. Two concurrent generates -- a double-tapped resend -- both read the same live rows, both expired them and both inserted, leaving two live OTPs while verify_otp_record only ever reads the newest, so the code the user was told about first could never verify while still spending the newer row's attempt budget.

And state on verify_otp that a failed verification is the only thing returned as a value: an unsupported or disabled channel, an unusable recipient and the rate limit all still raise, so a caller that treats a raise as "wrong code" reports a misconfigured channel to the user as a failed OTP.